### PR TITLE
Add Meridian to job sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Things you can do to increase your chance of success. Making an effort on these 
 
 <h2>Remote Jobs Directories</h2>
 <ul>
+  <li>Meridian: https://meridianremote.com/ (remote tech jobs matched to your timezone for US, LATAM, and EU; aggregated and deduplicated from top boards and ATS feeds)</li>
   <li>WeWorkRemotely: https://weworkremotely.com/</li>
   <li>Stackoverflow jobs: https://stackoverflow.com/jobs</li>
   <li>RemoteYeah: https://remoteyeah.com/</li>


### PR DESCRIPTION
Adds [Meridian](https://meridianremote.com) — a remote tech job board that matches roles to your timezone for US, LATAM, and EU professionals, aggregating and deduplicating listings from top boards and ATS feeds while linking to the original posting.